### PR TITLE
Upgrade Gradle to v7.1

### DIFF
--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionSha256Sum=0e46229820205440b48a5501122002842b82886e76af35f0f3a069243dca4b3c
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.0.2-bin.zip
+distributionSha256Sum=2debee19271e1b82c6e41137d78e44e6e841035230a1a169ca47fd3fb09ed87b
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.1-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/settings.gradle
+++ b/settings.gradle
@@ -31,7 +31,7 @@ include 'web'
 
 import org.gradle.util.GradleVersion
 
-def minGradleVersion = GradleVersion.version("7.0.2")
+def minGradleVersion = GradleVersion.version("7.1")
 def minJavaVersion = JavaVersion.VERSION_16
 if (GradleVersion.current() >= minGradleVersion && JavaVersion.current().isCompatibleWith(minJavaVersion)) {
     println "Building ${rootProject.name} module with ${GradleVersion.current()} and Java ${JavaVersion.current()}."


### PR DESCRIPTION
The most relevant change in v7.1 is the [caching of incremental compilation analysis](https://docs.gradle.org/current/release-notes.html#incremental-java) to speed up incremental builds. (I am seeing some <200ms inc. builds.)

A _"Deprecated Gradle features were used in this build, making it incompatible with Gradle 8.0"_ warning is sometimes logged during a build, but `./gradlew build --warning-mode all` does not tell us what in our build is deprecated.  I think the intermittent warning could be ignored until Gradle tells us something specific, and this warning might be due to some 3rd party plugin(s) we are using.