### PR TITLE
Rename Tor integration tests so Gradle will skip during build

### DIFF
--- a/tor/build.gradle
+++ b/tor/build.gradle
@@ -19,7 +19,7 @@ dependencies {
     implementation project(':common')
 
     implementation 'com.google.guava:guava'
-    
+
     implementation 'org.apache.commons:commons-compress'
 
     implementation 'com.github.chimp1984:jsocks'
@@ -34,4 +34,5 @@ dependencies {
 
 test {
     useJUnitPlatform()
+    exclude '**/**Integration*'
 }

--- a/tor/src/test/java/network/misq/tor/AsyncBootstrapIntegrationTest.java
+++ b/tor/src/test/java/network/misq/tor/AsyncBootstrapIntegrationTest.java
@@ -17,7 +17,7 @@ import static org.junit.jupiter.api.Assertions.fail;
 
 @Slf4j
 @TestMethodOrder(MethodOrderer.OrderAnnotation.class)
-public class AsyncBootstrapTest extends AbstractTorTest {
+public class AsyncBootstrapIntegrationTest extends AbstractTorTest {
 
     @Test
     @Order(1)

--- a/tor/src/test/java/network/misq/tor/BlockingBootstrapIntegrationTest.java
+++ b/tor/src/test/java/network/misq/tor/BlockingBootstrapIntegrationTest.java
@@ -9,7 +9,7 @@ import static org.junit.jupiter.api.Assertions.fail;
 
 @Slf4j
 @TestMethodOrder(MethodOrderer.OrderAnnotation.class)
-public class BlockingBootstrapTest extends AbstractTorTest {
+public class BlockingBootstrapIntegrationTest extends AbstractTorTest {
 
     @Test
     @Order(1)


### PR DESCRIPTION
To run `**/Integration*` tests in the IDE, configure the IDE to run tests from Intellij, not Gradle.