### PR TITLE
Remove String[] args from network service class constructors

### DIFF
--- a/application/src/main/java/network/misq/application/DefaultServiceProvider.java
+++ b/application/src/main/java/network/misq/application/DefaultServiceProvider.java
@@ -75,7 +75,7 @@ public class DefaultServiceProvider extends ServiceProvider {
         keyPairService = new KeyPairService(keyPairRepositoryConf);
 
         NetworkService.Config networkServiceConfig = NetworkServiceConfigFactory.getConfig(applicationOptions.baseDir(),
-                getConfig("misq.networkServiceConfig"), args);
+                getConfig("misq.networkServiceConfig"));
         networkService = new NetworkService(networkServiceConfig, keyPairService);
 
         identityService = new IdentityService(networkService);

--- a/application/src/main/java/network/misq/application/NetworkNodeServiceProvider.java
+++ b/application/src/main/java/network/misq/application/NetworkNodeServiceProvider.java
@@ -47,7 +47,7 @@ public class NetworkNodeServiceProvider extends ServiceProvider {
     private final NetworkService networkService;
     private final ApplicationOptions applicationOptions;
 
-    public NetworkNodeServiceProvider(ApplicationOptions applicationOptions, String[] args) {
+    public NetworkNodeServiceProvider(ApplicationOptions applicationOptions) {
         super("Seed");
         this.applicationOptions = applicationOptions;
 
@@ -55,7 +55,7 @@ public class NetworkNodeServiceProvider extends ServiceProvider {
         keyPairService = new KeyPairService(keyPairRepositoryConf);
 
         NetworkService.Config networkServiceConfig = NetworkServiceConfigFactory.getConfig(applicationOptions.baseDir(),
-                getConfig("misq.networkServiceConfig"), args);
+                getConfig("misq.networkServiceConfig"));
         networkService = new NetworkService(networkServiceConfig, keyPairService);
     }
 

--- a/network/src/main/java/network/misq/network/NetworkServiceConfigFactory.java
+++ b/network/src/main/java/network/misq/network/NetworkServiceConfigFactory.java
@@ -36,15 +36,8 @@ import java.util.stream.Collectors;
  */
 @Slf4j
 public class NetworkServiceConfigFactory {
+
     public static NetworkService.Config getConfig(String baseDir, Config typesafeConfig) {
-        return getConfig(baseDir, typesafeConfig, Optional.empty());
-    }
-
-    public static NetworkService.Config getConfig(String baseDir, Config typesafeConfig, String[] args) {
-        return getConfig(baseDir, typesafeConfig, Optional.of(args));
-    }
-
-    private static NetworkService.Config getConfig(String baseDir, Config typesafeConfig, Optional<String[]> args) {
         //  Set<Transport.Type> supportedTransportTypes = Set.of(Transport.Type.CLEAR, Transport.Type.TOR, Transport.Type.I2P);
         Set<Transport.Type> supportedTransportTypes = Set.of(Transport.Type.CLEAR, Transport.Type.TOR);
         // Set<Transport.Type> supportedTransportTypes = Set.of(Transport.Type.CLEAR);


### PR DESCRIPTION
Lightbend config library can use jvm-opts `-Dmisq.x.y` to override conf file values instead of `String[] programArguments`.